### PR TITLE
Added multi color support for link flow

### DIFF
--- a/imgui_node_editor.cpp
+++ b/imgui_node_editor.cpp
@@ -2750,7 +2750,7 @@ void ed::FlowAnimation::Draw(ImDrawList* drawList)
     const auto progress    = GetProgress();
 
     const auto flowAlpha = 1.0f - progress * progress;
-    const auto flowColor = Editor->GetColor(StyleColor_Flow, flowAlpha);
+    const auto flowColor = m_Link->m_FlowColor;
     //const auto flowPath  = Link->GetCurve();
 
     m_Link->Draw(drawList, flowColor, 2.0f);
@@ -2761,7 +2761,7 @@ void ed::FlowAnimation::Draw(ImDrawList* drawList)
 
         const auto markerAlpha  = powf(1.0f - progress, 0.35f);
         const auto markerRadius = 4.0f * (1.0f - progress) + 2.0f;
-        const auto markerColor  = Editor->GetColor(StyleColor_FlowMarker, markerAlpha);
+        const auto markerColor = m_Link->m_FlowColor;
 
         if (m_Link->m_SameNode) {
                 drawList->AddCircleFilled(m_Path[0].Point + ImVec2(0, m_Offset), markerRadius, markerColor);

--- a/imgui_node_editor.h
+++ b/imgui_node_editor.h
@@ -263,7 +263,7 @@ ImDrawList* GetNodeBackgroundDrawList(NodeId nodeId);
 bool Link(LinkId id, PinId startPinId, PinId endPinId, const ImVec4& color = ImVec4(255, 255, 255, 255), float thickness = 1.0f, bool sameNode = false);
 bool LinkDuplicates(const std::vector<uint64_t>& ids, PinId startPinId, PinId endPinId, const ImVec4& color, float thickness, bool sameNode);
 
-void Flow(LinkId linkId);
+void Flow(LinkId linkId, const ImVec4& color = ImVec4(255, 128, 64, 255));
 
 bool BeginCreate(const ImVec4& color = ImVec4(255, 255, 255, 255), float thickness = 1.0f);
 bool QueryNewLink(PinId* startId, PinId* endId);

--- a/imgui_node_editor_api.cpp
+++ b/imgui_node_editor_api.cpp
@@ -234,10 +234,12 @@ bool ax::NodeEditor::LinkDuplicates(const std::vector<uint64_t>& ids, PinId star
     return true;
 }
 
-void ax::NodeEditor::Flow(LinkId linkId)
+void ax::NodeEditor::Flow(LinkId linkId, const ImVec4& color)
 {
-    if (auto link = s_Editor->FindLink(linkId))
+    if (auto link = s_Editor->FindLink(linkId)) {
+        link->m_FlowColor = IM_COL32(color.x, color.y, color.z, color.w);
         s_Editor->Flow(link);
+    }
 }
 
 bool ax::NodeEditor::BeginCreate(const ImVec4& color, float thickness)

--- a/imgui_node_editor_internal.h
+++ b/imgui_node_editor_internal.h
@@ -439,7 +439,8 @@ struct Link final: Object
     LinkId m_ID;
     Pin*   m_StartPin;
     Pin*   m_EndPin;
-    ImU32  m_Color;
+    ImU32 m_Color;
+    ImU32 m_FlowColor;
     float  m_Thickness;
     ImVec2 m_Start;
     ImVec2 m_End;


### PR DESCRIPTION
By default node_editor only supports one color for all flow inside the whole editor. This PR adds a color parameter to flow to fix that